### PR TITLE
Update dataTables.fixedHeader.js

### DIFF
--- a/js/dataTables.fixedHeader.js
+++ b/js/dataTables.fixedHeader.js
@@ -332,6 +332,9 @@ $.extend( FixedHeader.prototype, {
 		var get = function ( name ) {
 			return $(name, from)
 				.map( function () {
+					if($(this).css('width')) {
+						return $(this).css('width');
+					}
 					return $(this).width();
 				} ).toArray();
 		};


### PR DESCRIPTION
Use the inline css width property if it exists as the new column width due to the width() function not always returning the correct value.

I am guessing if you accept this request, then you can apply it to other packages if needed and also update the version and minimize.